### PR TITLE
Centos7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,6 +24,9 @@ platforms:
         epel-testing:
           enabled: true
           managed: true
+      smokeping:
+        daemon_user: root
+        daemon_group: root
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,9 +24,6 @@ platforms:
         epel-testing:
           enabled: true
           managed: true
-      smokeping:
-        daemon_user: root
-        daemon_group: root
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,13 +8,26 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+    run_list:
+    - apt::default
   - name: ubuntu-14.04
+    run_list:
+    - apt::default
   - name: ubuntu-16.04
+    run_list:
+    - apt::default
+  - name: centos-7.2
+    run_list:
+    - yum-epel::default
+    attributes:
+      yum:
+        epel-testing:
+          enabled: true
+          managed: true
 
 suites:
   - name: default
     run_list:
-    - apt::default
     - smokeping::default
     attributes:
       smokeping:
@@ -23,7 +36,6 @@ suites:
         alert_email: "ExampleAlertEmail@localhost"
   - name: master
     run_list:
-    - apt::default
     - smokeping::example_master
     attributes:
       smokeping:
@@ -34,7 +46,6 @@ suites:
         alert_email: "ExampleAlertEmail@localhost"
   - name: slave
     run_list:
-    - apt::default
     - smokeping::example_slave
     attributes:
       smokeping:

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 
 group :integration do
   cookbook 'apt'
+  cookbook 'yum-epel'
 end

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Requirements
 ------------
 #### Platforms
 - Debian/Ubuntu
+- CentOS/RHEL 7.0+
 
 #### Chef
 - Chef 11+
@@ -61,6 +62,9 @@ provider.
 ```
 
 Apply the recipe to a the nodes runlist and run Chef
+
+For CentOS/RHEL support, epel or epel-testing repositories must be enabled.
+See yum-epel cookbook.
 
 License & Authors
 -----------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -41,14 +41,18 @@ when 'rhel'
   default['smokeping']['daemon_user'] = 'root'
   default['smokeping']['daemon_group'] = 'root'
   default['smokeping']['webroot'] = '/usr/share/smokeping/htdocs'
-  default['smokeping']['images'] = '/var/lib/smokeping/images'
+  default['smokeping']['imgcache'] = '/var/lib/smokeping/images'
+  default['smokeping']['datadir'] = '/var/lib/smokeping/rrd'
   default['smokeping']['cgi'] = '/usr/share/smokeping/cgi/smokeping.fcgi'
+  default['smokeping']['fping_path'] = '/sbin/fping'
 else
   default['smokeping']['daemon_user'] = 'smokeping'
   default['smokeping']['daemon_group'] = 'smokeping'
   default['smokeping']['webroot'] = '/usr/share/smokeping/www'
-  default['smokeping']['images'] = '/usr/share/smokeping/www/images'
+  default['smokeping']['imgcache'] = '/usr/share/smokeping/www/images'
+  default['smokeping']['datadir'] = '/var/lib/smokeping'
   default['smokeping']['cgi'] = '/usr/lib/cgi-bin/smokeping.cgi'
+  default['smokeping']['fping_path'] = '/usr/bin/fping'
 end
 
 default['smokeping']['alerts'] = [

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,9 +36,20 @@ default['smokeping']['smtp_host'] = nil
 
 default['smokeping']['syslog_facility'] = 'local0'
 
-# The name of the account the package creates for the smokeping daemon, or 'root'.
-default['smokeping']['daemon_user'] = 'smokeping'
-default['smokeping']['daemon_group'] = 'smokeping'
+case node['platform_family']
+when 'rhel'
+  default['smokeping']['daemon_user'] = 'root'
+  default['smokeping']['daemon_group'] = 'root'
+  default['smokeping']['webroot'] = '/usr/share/smokeping/htdocs'
+  default['smokeping']['images'] = '/var/lib/smokeping/images'
+  default['smokeping']['cgi'] = '/usr/share/smokeping/cgi/smokeping.fcgi'
+else
+  default['smokeping']['daemon_user'] = 'smokeping'
+  default['smokeping']['daemon_group'] = 'smokeping'
+  default['smokeping']['webroot'] = '/usr/share/smokeping/www'
+  default['smokeping']['images'] = '/usr/share/smokeping/www/images'
+  default['smokeping']['cgi'] = '/usr/lib/cgi-bin/smokeping.cgi'
+end
 
 default['smokeping']['alerts'] = [
   {

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,6 +36,10 @@ default['smokeping']['smtp_host'] = nil
 
 default['smokeping']['syslog_facility'] = 'local0'
 
+# The name of the account the package creates for the smokeping daemon, or 'root'.
+default['smokeping']['daemon_user'] = 'smokeping'
+default['smokeping']['daemon_group'] = 'smokeping'
+
 default['smokeping']['alerts'] = [
   {
     'name' => 'bigloss',

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version '1.1.6'
 depends 'apache2'
 depends 'perl'
 
-%w(debian ubuntu).each do |os|
+%w(centos debian redhat ubuntu).each do |os|
   supports os
 end
 

--- a/recipes/_apache.rb
+++ b/recipes/_apache.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 include_recipe 'apache2'
+include_recipe 'apache2::mod_cgi'
 include_recipe 'apache2::mod_rewrite'
 
 file '/etc/smokeping/apache2.config' do

--- a/recipes/_apache.rb
+++ b/recipes/_apache.rb
@@ -23,7 +23,7 @@ file '/etc/smokeping/apache2.config' do
   action :delete
 end
 
-template '/etc/apache2/sites-available/smokeping.conf' do
+template "#{node['apache']['dir']}/sites-available/smokeping.conf" do
   source 'apache2.erb'
   mode '0644'
   notifies :reload, 'service[apache2]'

--- a/recipes/_packages.rb
+++ b/recipes/_packages.rb
@@ -31,7 +31,7 @@ when 'debian'
     action :nothing
   end
 
-  template 'smokeping' do
+  template 'smokeping init.d' do
     path '/etc/init.d/smokeping'
     source 'smokeping.init.erb'
     owner 'root'
@@ -56,4 +56,40 @@ else
     mode 0755
     action :create
   end
+end
+
+template "#{node['smokeping']['etc_dir']}/config" do
+  source 'config.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies :reload, 'service[smokeping]'
+end
+
+%w(pathnames Database Presentation Probes).each do |configdfile|
+  template "#{node['smokeping']['etc_dir']}/config.d/#{configdfile}" do
+    source "#{configdfile}.erb"
+    owner 'root'
+    group 'root'
+    mode 0644
+    notifies :reload, 'service[smokeping]'
+  end
+end
+
+# Create empty Target and Slave list files to prevent smokeping from failing to start on initial converge
+file "#{node['smokeping']['etc_dir']}/config.d/Targets" do
+  action :create_if_missing
+  content '*** Targets ***'
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies :reload, 'service[smokeping]'
+end
+
+file "#{node['smokeping']['etc_dir']}/config.d/Slaves" do
+  action :create_if_missing
+  owner 'root'
+  group 'root'
+  mode 0644
+  notifies :reload, 'service[smokeping]'
 end

--- a/recipes/master.rb
+++ b/recipes/master.rb
@@ -39,8 +39,8 @@ if node['smokeping']['master_mode']
   template secret_path do
     source 'smokeping_secrets.erb'
     mode '0400'
-    owner 'smokeping'
-    group 'smokeping'
+    owner node['smokeping']['daemon_user']
+    group node['smokeping']['daemon_group']
     variables(
       secrets: slavesecrets,
       path: secret_path

--- a/recipes/slave.rb
+++ b/recipes/slave.rb
@@ -27,8 +27,8 @@ if node['smokeping']['slave_mode']
 
   template secret_path do
     source 'secret.txt.erb'
-    owner 'smokeping'
-    group 'smokeping'
+    owner node['smokeping']['daemon_user']
+    group node['smokeping']['daemon_group']
     mode '0400'
     variables(
       secret: secret

--- a/templates/default/Database.erb
+++ b/templates/default/Database.erb
@@ -1,0 +1,16 @@
+*** Database ***
+
+step     = 300
+pings    = 20
+
+# consfn mrhb steps total
+
+AVERAGE  0.5   1  1008
+AVERAGE  0.5  12  4320
+    MIN  0.5  12  4320
+    MAX  0.5  12  4320
+AVERAGE  0.5 144   720
+    MAX  0.5 144   720
+    MIN  0.5 144   720
+
+

--- a/templates/default/Presentation.erb
+++ b/templates/default/Presentation.erb
@@ -1,0 +1,56 @@
+*** Presentation ***
+
+template = /etc/smokeping/basepage.html
+charset  = utf-8
+
++ charts
+
+menu = Charts
+title = The most interesting destinations
+
+++ stddev
+sorter = StdDev(entries=>4)
+title = Top Standard Deviation
+menu = Std Deviation
+format = Standard Deviation %f
+
+++ max
+sorter = Max(entries=>5)
+title = Top Max Roundtrip Time
+menu = by Max
+format = Max Roundtrip Time %f seconds
+
+++ loss
+sorter = Loss(entries=>5)
+title = Top Packet Loss
+menu = Loss
+format = Packets Lost %f
+
+++ median
+sorter = Median(entries=>5)
+title = Top Median Roundtrip Time
+menu = by Median
+format = Median RTT %f seconds
+
++ overview
+
+width = 600
+height = 50
+range = 10h
+
++ detail
+
+width = 600
+height = 200
+unison_tolerance = 2
+
+"Last 3 Hours"    3h
+"Last 30 Hours"   30h
+"Last 10 Days"    10d
+"Last 360 Days"   360d
+
+#+ hierarchies
+#++ owner
+#title = Host Owner
+#++ location
+#title = Location

--- a/templates/default/Probes.erb
+++ b/templates/default/Probes.erb
@@ -1,0 +1,5 @@
+*** Probes ***
+
++ FPing
+
+binary = <%= node['smokeping']['fping_path'] %>

--- a/templates/default/apache2.erb
+++ b/templates/default/apache2.erb
@@ -6,17 +6,17 @@
   ServerName      <%= node['smokeping']['server_name'] %>
   <% if node['smokeping']['server_alias'] %>ServerAlias     <%= node['smokeping']['server_alias'] %><% end %>
 
-  DocumentRoot /var/www
+  DocumentRoot <%= node['smokeping']['webroot'] %>
 
   RewriteEngine on
   RewriteCond %{REQUEST_URI} !^/smokeping/.+
   RewriteCond %{REQUEST_URI} !^/smokeping\.cgi
   RewriteRule ^(.*)$ /smokeping.cgi [R=301]
 
-  Alias /smokeping/images <%= node['smokeping']['images'] %>
+  Alias /smokeping/images <%= node['smokeping']['imgcache'] %>
   Alias /smokeping <%= node['smokeping']['webroot'] %>
 
-  <Directory "<%= node['smokeping']['images'] %>">
+  <Directory "<%= node['smokeping']['imgcache'] %>">
       Options FollowSymLinks
       <%if node['apache']['version'].to_f >= 2.4 %>
       Require all granted

--- a/templates/default/apache2.erb
+++ b/templates/default/apache2.erb
@@ -9,12 +9,24 @@
   DocumentRoot /var/www
 
   RewriteEngine on
-  RewriteCond %{REQUEST_URI} !smokeping\.cgi
-  RewriteCond %{REQUEST_URI} !images
+  RewriteCond %{REQUEST_URI} !^/smokeping/.+
+  RewriteCond %{REQUEST_URI} !^/smokeping\.cgi
   RewriteRule ^(.*)$ /smokeping.cgi [R=301]
 
-  Alias /smokeping /usr/share/smokeping/www
-  <Directory "/usr/share/smokeping/www">
+  Alias /smokeping/images <%= node['smokeping']['images'] %>
+  Alias /smokeping <%= node['smokeping']['webroot'] %>
+
+  <Directory "<%= node['smokeping']['images'] %>">
+      Options FollowSymLinks
+      <%if node['apache']['version'].to_f >= 2.4 %>
+      Require all granted
+      <% else %>
+      Order allow,deny
+      Allow from all
+      <% end %>
+  </Directory>
+
+  <Directory "<%= node['smokeping']['webroot'] %>">
       Options FollowSymLinks
   </Directory>
 
@@ -22,12 +34,16 @@
     AuthName "Smokeping Server"
   </Location>
 
-  ScriptAlias / /usr/lib/cgi-bin/
-  <Directory "/usr/lib/cgi-bin">
+  ScriptAlias /smokeping.cgi <%= node['smokeping']['cgi'] %>
+  <Directory "<%= File.dirname(node['smokeping']['cgi']) %>">
     AllowOverride None
-    Options ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    <%if node['apache']['version'].to_f >= 2.4 %>
+    Require all granted
+    <% else %>
     Order allow,deny
     Allow from all
+    <% end %>
   </Directory>
 
 </VirtualHost>

--- a/templates/default/config.erb
+++ b/templates/default/config.erb
@@ -1,0 +1,7 @@
+@include /etc/smokeping/config.d/General
+@include /etc/smokeping/config.d/Alerts
+@include /etc/smokeping/config.d/Database
+@include /etc/smokeping/config.d/Presentation
+@include /etc/smokeping/config.d/Probes
+@include /etc/smokeping/config.d/Slaves
+@include /etc/smokeping/config.d/Targets

--- a/templates/default/pathnames.erb
+++ b/templates/default/pathnames.erb
@@ -1,0 +1,7 @@
+sendmail = /usr/sbin/sendmail
+imgcache = <%= node['smokeping']['imgcache'] %>
+imgurl   = ../smokeping/images
+datadir  = <%= node['smokeping']['datadir'] %>
+piddir  = /var/run/smokeping
+smokemail = <%= node['smokeping']['etc_dir'] %>/smokemail
+tmail = <%= node['smokeping']['etc_dir'] %>/tmail

--- a/templates/default/smokeping.init.erb
+++ b/templates/default/smokeping.init.erb
@@ -98,7 +98,7 @@ case "$1" in
         check_config
         check_slave
         set +e
-        pidofproc "$DAEMON" > /dev/null
+        pidofproc -p "$PIDFILE" "$DAEMON" > /dev/null
         STATUS=$?
         set -e
         if [ "$STATUS" = 0 ]
@@ -181,7 +181,7 @@ case "$1" in
         # 5-199    reserved (5-99 LSB, 100-149 distribution, 150-199 applications)
 
         set +e
-        pidofproc "$DAEMON" > /dev/null
+        pidofproc -p "$PIDFILE" "$DAEMON" > /dev/null
         STATUS=$?
         log_progress_msg "(status $STATUS)"
         log_end_msg 0

--- a/test/integration/master/serverspec/smokeping_spec.rb
+++ b/test/integration/master/serverspec/smokeping_spec.rb
@@ -12,3 +12,18 @@ describe 'Smokeping daemon' do
     expect(service('smokeping')).to be_running
   end
 end
+
+describe command('curl -I localhost/smokeping.cgi') do
+  its(:stdout) { should match('HTTP/1.1 200 OK') }
+  its(:exit_status) { should eq(0) }
+end
+
+describe command('curl -I localhost/smokeping/images/smokeping.png') do
+  its(:stdout) { should match('HTTP/1.1 200 OK') }
+  its(:exit_status) { should eq(0) }
+end
+
+describe command('curl http://localhost/smokeping.cgi?target=Production.slave1') do
+  its(:stdout) { should match('Production.slave2') }
+  its(:exit_status) { should eq(0) }
+end


### PR DESCRIPTION
This PR adds CentOS/RHEL support and some other improvements.

This depends on a smokeping package currently being developed for RHEL 7. It has recently been added to [EPEL](http://koji.fedoraproject.org/koji/packageinfo?packageID=7035) but is still in epel-testing.  As such kitchen uses epel-testing for the time being.  
- A bug fix has been added to the init.d script, taken form ubuntu the 16.04 version, fixing a bug causing `service smokeping status` to return the wrong error code.  This was causing tests to fail.
- Tests have been added to verify smokeping.cgi on the master is actually working.
- Much of the apache vhost has been parameterized and some minor apache compatibility issues corrected.
