### PR TITLE
Fix apache2 configuration

### DIFF
--- a/recipes/_apache.rb
+++ b/recipes/_apache.rb
@@ -18,6 +18,7 @@
 
 include_recipe 'apache2'
 include_recipe 'apache2::mod_rewrite'
+apache_module 'cgi'
 
 file '/etc/smokeping/apache2.config' do
   action :delete

--- a/templates/apache2.erb
+++ b/templates/apache2.erb
@@ -15,7 +15,7 @@
 
   Alias /smokeping /usr/share/smokeping/www
   <Directory "/usr/share/smokeping/www">
-      Options FollowSymLinks
+      Options +FollowSymLinks
   </Directory>
 
   <Location />
@@ -25,9 +25,8 @@
   ScriptAlias / /usr/lib/cgi-bin/
   <Directory "/usr/lib/cgi-bin">
     AllowOverride None
-    Options ExecCGI -MultiViews +SymLinksIfOwnerMatch
-    Order allow,deny
-    Allow from all
+    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
+    Require all granted
   </Directory>
 
 </VirtualHost>


### PR DESCRIPTION
The configuration as shipped just plain does not work with Ubuntu 14.04, because Ubuntu 14.04 ships with Apache 2.4, and the configuration style for the ACLs and Options blocks are Apache 2.2 style.

Also added in a missing necessary module.

Obvious fix.